### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Some samples in this repositories may have special deployment instructions. Refe
 3. Use gcloud to deploy your app.
 
    ```
-   gcloud preview app deploy
+   gcloud app deploy
    ```
 
 4. Congratulations!  Your application is now live at `your-app-id.appspot.com`

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -9,4 +9,4 @@ Simple sample of a [Sinatra][http://www.sinatrarb.com/] app that runs on [Google
 
 ## Deploy
 
-    $ gcloud preview app deploy
+    $ gcloud app deploy


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.