### PR TITLE
Make ruby example functional.

### DIFF
--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -11,3 +11,6 @@ RUN bundle install --deployment --without="development test"
 ENV RACK_ENV=production \
     RAILS_ENV=production \
     RAILS_SERVE_STATIC_FILES=true    
+
+CMD ["bundle", "exec", "ruby", "app.rb"]
+


### PR DESCRIPTION
Fixes #18, allows ruby to actually say hello. I also agree with #19, it was bewildering to find that the docker image itself was the thing that was broken and not app engine.