### PR TITLE
fixed the package swift otherwise it fails

### DIFF
--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,8 +1,16 @@
+// swift-tools-version:4.2
+
 import PackageDescription
 
 let package = Package(
-    name: "MyApplication",
-    dependencies: [
-        .Package(url: "https://github.com/IBM-Swift/Kitura.git", majorVersion: 1, minor: 6)
-    ]
+  name: "MyApplication",
+  dependencies: [
+    .package(url: "https://github.com/IBM-Swift/Kitura.git",
+      .upToNextMajor(from: "2.0.0"))
+  ],
+  targets: [
+    .target(name: "MyApplication",
+      dependencies: ["Kitura"],
+      path: "Sources")
+  ]
 )


### PR DESCRIPTION
this fixes the error "Swift tools version 3.1.0 which is no longer supported; use 4.0.0 or newer instead" when you try to deploy the swift app